### PR TITLE
NEW Add default base content blocks page type BlocksPage with subsites configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,9 @@
         "dnadesign/silverstripe-elemental-userforms": "Add integration logic for Elemental and Userforms"
     },
     "extra": {
-        "project-files": [],
+        "project-files": [
+            "mysite/*"
+        ],
         "branch-alias": {
             "dev-master": "1.x-dev"
         }

--- a/mysite/_config/contentblocks.yml
+++ b/mysite/_config/contentblocks.yml
@@ -1,0 +1,15 @@
+---
+Name: mysitecontentblocks
+---
+BlocksPage:
+  extensions:
+    - DNADesign\Elemental\Extensions\ElementalPageExtension
+
+---
+Name: contentblockssubsites
+Only:
+  moduleexists: dnadesign/silverstripe-elemental-subsites
+---
+DNADesign\Elemental\Models\BaseElement:
+  extensions:
+    - DNADesign\ElementalSubsites\Extensions\ElementalSubsiteExtension

--- a/mysite/code/BlocksPage.php
+++ b/mysite/code/BlocksPage.php
@@ -1,0 +1,8 @@
+<?php
+
+class BlocksPage extends Page
+{
+    private static $table_name = 'BlocksPage';
+
+    private static $description = 'A modular page composed of content blocks';
+}


### PR DESCRIPTION
This adds a new page type which projects using content blocks can use. This will avoid applying the elemental extension to the Page class which will introduce side effects from other modules which may not be intended.

Resolves https://github.com/dnadesign/silverstripe-elemental/issues/176