### PR TITLE
amend test suite

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
 <phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
     <testsuite name="recipe-content-blocks">
         <directory>vendor/dnadesign/silverstripe-elemental/tests</directory>
-        <directory>vendor/silverstripe/elemental-blocks/tests</directory>
+        <directory>vendor/silverstripe/elemental-fileblock/tests</directory>
+        <directory>vendor/silverstripe/elemental-bannerblock/tests</directory>
     </testsuite>
 </phpunit>


### PR DESCRIPTION
Update the phpunit test suite to include the newly split out modules - what used to be `silverstripe/elemental-blocks` is now a separate module per block it contained.