### PR TITLE
FIX Change branch-alias to 3.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
             "app/*"
         ],
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "3.x-dev"
         }
     },
     "config": {


### PR DESCRIPTION
Update branch-alias to 3.x-dev so `composer require silverstripe/recipe-content-blocks:2.x-dev` installs `2.x-dev` rather than `dev-master`