### PR TITLE
MNT Require ^3.8 of graphql for dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "silverstripe/elemental-bannerblock": "2.4.x-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "silverstripe/graphql": "^3.8"
     },
     "suggest": {
         "dnadesign/silverstripe-elemental-userforms": "Add integration logic for Elemental and Userforms"


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Fixes
https://github.com/silverstripe/recipe-content-blocks/runs/7440641087?check_suite_focus=true#step:12:67

```
 1) DNADesign\Elemental\Tests\Legacy\GraphQL\AddElementToAreaMutationTest::testAddingBlocksInOrder
Error: Class 'SilverStripe\GraphQL\Tests\Fake\FakeResolveInfo' not found
```