### PR TITLE
API Deprecate API that's changing in CMS 6

### DIFF
--- a/app/src/BlocksPage.php
+++ b/app/src/BlocksPage.php
@@ -11,5 +11,8 @@ class BlocksPage extends Page
 
     private static $class_description = 'A modular page composed of content blocks';
 
+    /**
+     * @deprecated 5.4.0 Will be renamed to cms_icon_class
+     */
     private static $icon_class = 'font-icon-p-alt';
 }


### PR DESCRIPTION
Note that while this recipe won't be supported in CMS 6, the API is changing in superclasses which live in modules that WILL be supported, which means this API will change regardless.

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2947